### PR TITLE
Broken % command?

### DIFF
--- a/colors/detailed.vim
+++ b/colors/detailed.vim
@@ -598,7 +598,7 @@ fun! s:detailed_colors()
   call s:fg('detailedInstanceVariable', 'blue75')
 
   call s:fgbg('detailedString', 'purple125', 'gray233')
-  call s:fgbg('detailedInterpolatedString', 'purple126', 'gray233')
+  call s:fgbg('rubyString', 'purple126', 'gray233')
   call s:bold_fgbg('detailedExecutedString', 'green34', 'purple53')
   call s:fgbg('detailedRawString', 'red160', 'gray233')
   call s:fg('detailedStringDelimiter', 'blue33')
@@ -740,7 +740,7 @@ fun! s:ruby_syntax_and_highlights()
   syn match detailedExits "\<\%(exit!\|\%(abort\|at_exit\|exit\|fork\|trap\)\>[?!]\@!\)"
 
   " TODO: also handle %(…), etc
-  syn region detailedInterpolatedString matchgroup=detailedInterpolatedStringDelimiter start="\"" end="\"" skip="\\\\\|\\\"" contains=@rubyStringSpecial,@Spell fold
+  syn region rubyString matchgroup=detailedInterpolatedStringDelimiter start="\"" end="\"" skip="\\\\\|\\\"" contains=@rubyStringSpecial,@Spell fold
   " TODO: Also, %x(). Anything else?
   syn region detailedExecutedString matchgroup=detailedExecutedStringDelimiter start="`" end="`"  skip="\\\\\|\\`"  contains=@rubyStringSpecial fold
 


### PR DESCRIPTION
I have a ruby file called `foo.rb`:

``` ruby
1  foo("thing thang") do
2    some.code("here do")
3  end
```

If I put my cursor on line 3 and hit `%`, it should jump to the end of line 1. Instead, it jumps to the end of the string in line 2. I did a binary search through [my .vimrc](https://github.com/benhamill/dotfiles/blob/master/home/.vimrc) and figured out that when I comment out [this line](https://github.com/benhamill/dotfiles/blob/master/home/.vimrc#L122), the expected behavior returns.

I noticed this when writing RSpec examples when `it "doesn't do anything"` and `it "adds the header to the array for the existing record"`. Both "do" and "for" caused `%` to freak out.

I have no idea what might cause a color scheme to have this kind of effect, but...

Anyone else replicate this or have an idea of what might be the cause? Or where, at least, to start poking around in this code base to find something?
