### PR TITLE
Modernize ruby

### DIFF
--- a/colors/detailed.vim
+++ b/colors/detailed.vim
@@ -747,6 +747,22 @@ fun! s:ruby_syntax_and_highlights()
   " The default syntax/ruby.vim gets this way wrong (only does 2 chars and is
   " transparent):
   syn match rubyBlockArgument "&[_[:lower:]][_[:alnum:]]*" contains=NONE display
+
+  " This was disabled in
+  " https://github.com/vim-ruby/vim-ruby/commit/074200ffa39b19baf9d9750d399d53d97f21ee07
+  " and removed in
+  " https://github.com/vim-ruby/vim-ruby/commit/eba523334fe14e5c9b9585a287a336317da26d70
+  hi def link rubyBlockParameter rubyIdentifier
+  syn match rubyBlockParameter "\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*" contained
+  syn cluster rubyDeclaration add=rubyBlockParameter
+  hi link rubyBlockParameter detailedBlockParameter
+  syn region rubyBlockParameterList start="\%(\%(\<do\>\|{\)\_s*\)\@32<=|" end="|" contains=rubyBlockParameter,rubySplatOperator,rubyDoubleSplatOperator,rubyProcOperator
+  " This is new though
+  syn match rubyNumberedBlockParam "_[1-9]" display
+  syn match rubyNumberedBlockParamError "_0" display
+  hi link rubyNumberedBlockParam rubyBlockParameter
+  hi def link rubyNumberedBlockParamError	rubyError
+
   " Bonus!
   syn match detailedInitialize '\<initialize\>' contained containedin=rubyMethodDeclaration
 

--- a/colors/detailed.vim
+++ b/colors/detailed.vim
@@ -748,49 +748,36 @@ fun! s:ruby_syntax_and_highlights()
   " transparent):
   syn match rubyBlockArgument "&[_[:lower:]][_[:alnum:]]*" contains=NONE display
   " Bonus!
-  syn match rubyInitialize '\<initialize\>' contained containedin=rubyMethodDeclaration
+  syn match detailedInitialize '\<initialize\>' contained containedin=rubyMethodDeclaration
 
-  syn match rubyEncodingDirective "\cencoding: *utf-8" contained
-
-  " TODO - make this more elegant.
-  syn match rubyFirstAndSecondCommentLine '\%^#.*'
-        \ contains=rubyEncodingDirective contained
-  syn match rubyFirstAndSecondCommentLine '\%^#.*\n#.*'
-        \ contains=rubyEncodingDirective contained
-
-  syn match   rubyComment   "#.*" contains=rubySharpBang,rubySpaceError,
-        \rubyFirstAndSecondCommentLine,detailedTodo,detailedFixme,detailedXxx,@Spell
+  syn match   rubyComment   "#.*" contains=@rubyCommentSpecial,rubySpaceError,
+        \detailedTodo,detailedFixme,detailedXxx,@Spell
 
   hi link rubyConditional  Conditional
-  hi link rubyExceptional  rubyConditional " No-show.
-  hi link rubyMethodExceptional  rubyDefine " And another.
+  hi link rubyExceptionHandler  rubyConditional " No-show.
   hi link rubyStringEscape  Special
   hi link rubyQuoteEscape  rubyStringEscape
-  hi link rubyInvalidVariable  Error
-  hi link rubyNoInterpolation  rubyString " E.g. \#{} inside a string.
   hi link rubyException   Exception
   hi link rubyKeyword     Keyword
   hi link rubyConstant detailedConstant
-  hi link rubyEncodingDirective detailedEncodingDirective
-  hi link rubyInitialize detailedInitialize
-  hi link rubyRailsARAssociationMethod detailedRailsARAssociationMethod
+  hi link rubyEncoding detailedEncodingDirective
+  hi link rubyEntity detailedRailsARAssociationMethod
   hi link rubySpaceError BadWhitespace
   hi link rubyData detailedData
   hi link rubyDataDirective detailedDataDirective
-  hi link rubyDocumentation  Comment
-  hi link rubyComment Comment
   hi link rubyFirstAndSecondCommentLine rubySharpBang
   hi link rubySharpBang detailedSharpBang
-  hi link rubyDoBlock rubyRepeatExpression
+  hi link rubyDoBlock detailedRepeatExpression
   hi link rubyRepeatExpression detailedRepeatExpression
   hi link rubyRepeatModifier detailedRepeatModifier
   hi link rubyRepeat detailedRepeat
-  hi link rubyCaseExpression rubyConditionalExpression
+  hi link rubyCaseExpression detailedConditionalExpression
   hi link rubyConditionalExpression detailedConditionalExpression
   hi link rubyConditionalModifier detailedConditionalModifier
   hi link rubyControl detailedControl
   hi link rubyBlockExpression detailedBlockExpression
-  hi link rubyBlock detailedBlock
+  hi link rubyClassBlock detailedBlock
+  hi link rubyModuleBlock detailedBlock
   hi link rubyMethodBlock detailedMethodBlock
   hi link rubyEval detailedEval
   hi link rubyAttribute detailedAttribute
@@ -802,20 +789,18 @@ fun! s:ruby_syntax_and_highlights()
   hi link rubyPredefinedVariable detailedPredefinedVariable
   hi link rubyPredefinedConstant detailedPredefinedConstant
   hi link rubyBlockParameterList detailedBlockParameterList
-  hi link rubyBlockParameter detailedBlockParameter
   hi link rubySymbol detailedSymbol
   hi link rubyBlockArgument detailedBlockArgument
   hi link rubyFloat detailedFloat
   hi link rubyInteger detailedInteger
   hi link rubyPseudoVariable detailedPseudoVariable
-  hi link rubyASCIICode detailedASCIICode
+  hi link rubyCharacter detailedASCIICode
   hi link rubyRegexpDelimiter detailedRegexpDelimiter
   hi link rubyRegexpDot detailedRegexpDot
   hi link rubyRegexpAnchor detailedRegexpAnchor
   hi link rubyRegexpEscape detailedRegexpEscape
   hi link rubyRegexpQuantifier detailedRegexpQuantifier
   hi link rubyRegexpCharClass detailedRegexpCharClass
-  hi link rubyRegexpComment Comment
   hi link rubyRegexpSpecial detailedRegexpSpecial
   hi link rubyInterpolationDelimiter detailedInterpolationDelimiter
   hi link rubyStringDelimiter detailedStringDelimiter


### PR DESCRIPTION
I went through vim-ruby's syntax/ruby.vim and renamed or removed syntax names
that had been changed there.

I also renamed vim-detailed original names to avoid implying that the syntax
came from vim-ruby, such as {-ruby-}{+detailed+}Initialize.

Finally, I removed highlight links that already existed in vim-ruby.

For somewhat arbitrary reasons it seems that rubyBlockParameter was removed from
vim-ruby's syntax/ruby.vim. Re-add it so that we have something to link the new
rubyNumberedBlockParam to, and also because I vaguely remember having it and it
was nice.

Also introduce rubyNumberedBlockParamError to help Rubyists avoid using `_0` by
mistake.